### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR for appending to CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(bxzstr)
 
 ## For FindZstd
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 if(DEFINED ZLIB_FOUND)
   if(ZLIB_FOUND)


### PR DESCRIPTION
Using CMAKE_CURRENT_SOURCE_DIR to append to CMAKE_MODULE_PATH enables building this project through Fetch_Content based "package" systems such as CPM