### PR TITLE
allow manual specification of decompression method

### DIFF
--- a/include/compression_types.hpp
+++ b/include/compression_types.hpp
@@ -17,7 +17,7 @@
 #include "zstd_stream_wrapper.hpp"
 
 namespace bxz {
-    enum Compression { z, bz2, lzma, zstd, plaintext };
+    enum Compression { z, bz2, lzma, zstd, plaintext, none };
 inline Compression detect_type(const char* in_buff_start,const  char* in_buff_end) {
     const unsigned char b0 = *reinterpret_cast<const  unsigned char * >(in_buff_start);
     const unsigned char b1 = *reinterpret_cast<const  unsigned char * >(in_buff_start + 1);


### PR DESCRIPTION
This PR adds new constructors for `bxz::istreambuf`, `bxz::istream`, `bxz::ifstream` that allow the specification of the decompression method.

This is a a simple work-around for missing automatic detection of certain compression types, see https://github.com/mateidavid/zstr/issues/27 and https://github.com/tmaklin/bxzstr/issues/31.

Sample usage:
```c++
    bxz::ifstream input(file, std::ios_base::in, bxz::zstd);
```

Fixes #31.