### PR TITLE
silence a compiler warning

### DIFF
--- a/include/bxzstr.hpp
+++ b/include/bxzstr.hpp
@@ -61,7 +61,7 @@ class istreambuf : public std::streambuf {
         return seekpos(pos, which);
     }
 
-    virtual std::streampos seekpos(std::streampos pos, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out){
+    virtual std::streampos seekpos(std::streampos pos, std::ios_base::openmode){
         if(pos == 0){
             seek_to_zero(); // reset the stream
             return 0; // this should not fail


### PR DESCRIPTION
This PR removes a parameter name for an unused variable to silence the following compiler warning.
```
bxzstr.hpp: In member function 'virtual std::streampos bxz::istreambuf::seekpos(std::streampos, std::ios_base::openmode)':
bxzstr.hpp:64:80: warning: unused parameter 'which' [-Wunused-parameter]
   64 | reampos seekpos(std::streampos pos, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out){
```