### PR TITLE
clean up and readme edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ functionality of this library remains largely the same.
 
 ## Input detection
 
-The library automatically detects whether the input stream is
+The library can automatically detect whether the input stream is
 compressed or not, and with which algorithm. The detection is based on
 identifying the headers based on the magic numbers:
 * GZip header, starting with **1F 8B**
@@ -22,7 +22,7 @@ identifying the headers based on the magic numbers:
 * LZMA header, starting with **FD 37 7A 58 5A 00**
 * ZSTD header, starting with **28 B5 2F FD**
 
-when no header is identified, the stream is treated as plain text (uncompressed).
+when no header is identified, the stream is treated as plain text (uncompressed). Alternatively, the compression algorithm can be specified by the user.
 
 ## Usage
 The streams can be accessed through 6 classes that function similarly

--- a/include/bxzstr.hpp
+++ b/include/bxzstr.hpp
@@ -37,20 +37,8 @@ class istreambuf : public std::streambuf {
         out_buff = new char [buff_size];
         setg(out_buff, out_buff, out_buff);
     }
-    istreambuf(std::streambuf * _sbuf_p, Compression type, std::size_t _buff_size = default_buff_size)
-            : sbuf_p(_sbuf_p),
-	      strm_p(nullptr),
-	      buff_size(_buff_size),
-	      auto_detect(false),
-	      auto_detect_run(false),
-        type(type) {
-        assert(sbuf_p);
-        in_buff = new char [buff_size];
-        in_buff_start = in_buff;
-        in_buff_end = in_buff;
-        out_buff = new char [buff_size];
-        setg(out_buff, out_buff, out_buff);
-    }
+    istreambuf(std::streambuf * _sbuf_p, Compression _type, std::size_t _buff_size = default_buff_size)
+            : istreambuf(_sbuf_p, _buff_size, false) { type = _type; }
     istreambuf(const istreambuf &) = delete;
     istreambuf(istreambuf &&) = default;
     istreambuf & operator = (const istreambuf &) = delete;
@@ -328,6 +316,8 @@ class ifstream : public detail::strict_fstream_holder< strict_fstream::ifstream 
         this->setstate(_fs.rdstate());
         exceptions(std::ios_base::badbit);
     }
+    explicit ifstream(const std::string& filename, Compression type)
+              : ifstream(filename, std::ios_base::in, type) {}
     ifstream(const ifstream& other) : ifstream(other.filename, other.mode, other.type) {}
     virtual ~ifstream() { if (rdbuf()) delete rdbuf(); }
 


### PR DESCRIPTION
This PR offers a cleaner implementation of the new `istreambuf` constructor introduced in https://github.com/tmaklin/bxzstr/pull/32. We also add a new overloaded `ifstream` constructor, allowing the simpler syntax
```
bxz::ifstream input(file, bxz::zstd);
```
as for `ofstream`.

Also edit the readme.